### PR TITLE
style(lib): implement lib/ folder for reusable components

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import Button from "../../lib/button/Button";
 
 const Home = () => {
   const [userData, setUserData] = React.useState(null);
@@ -47,12 +48,20 @@ const Home = () => {
       {userData && userData.avatar_url && (
         <div>
           <img src={userData.avatar_url} alt="Profile" className="avatar" />
-          <p>Welcome <em><strong>{userData?.name}!</strong></em></p>
+          <p>
+            Welcome{" "}
+            <em>
+              <strong>{userData?.name}!</strong>
+            </em>
+          </p>
         </div>
       )}
       {!userData && <p>Please login to continue.</p>}
 
-      <button onClick={redirectToLogin}> Get Started!</button>
+      {/* <button onClick={redirectToLogin}> Get Started!</button> */}
+      <Button onClick={redirectToLogin} variant="primary">
+        Get Started!
+      </Button>
     </>
   );
 };

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import "./Login.css";
+import Button from "../../lib/button/Button.jsx";
 
 const Login = ({ onLogin }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -15,7 +16,7 @@ const Login = ({ onLogin }) => {
         if (!token) {
           setIsLoading(false);
           return;
-        };
+        }
 
         const response = await fetch(`${API_BASE_URL}/auth/user`, {
           credentials: "include",
@@ -31,15 +32,15 @@ const Login = ({ onLogin }) => {
           setIsLoading(false);
         }
       } catch (err) {
-          setIsLoading(false);
-          setLoggedIn(false);
-          console.error("Error checking login status:", err);
+        setIsLoading(false);
+        setLoggedIn(false);
+        console.error("Error checking login status:", err);
       }
     };
 
     checkLoginStatus();
   }, []);
-  
+
   const handleGoogleLogin = async () => {
     setIsLoading(true);
     setError(null);
@@ -53,13 +54,13 @@ const Login = ({ onLogin }) => {
   return (
     <div className="login-container">
       <span>Sign in to YDO</span>
-      <button
+      <Button
         onClick={handleGoogleLogin}
         disabled={isLoading}
-        className="google-btn"
+        className="primary"
       >
         {isLoading ? "loading..." : "Sign in with Google"}
-      </button>
+      </Button>
       {error && <p className="error-message">{error}</p>}
     </div>
   );

--- a/src/lib/button/Button.css
+++ b/src/lib/button/Button.css
@@ -1,0 +1,64 @@
+.btn {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.25s ease-in-out;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Variants */
+.btn-primary {
+  background-color: #4f46e5;
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: #4338ca;
+}
+
+.btn-secondary {
+  background-color: #f3f4f6;
+  color: #111827;
+  border: 1px solid #d1d5db;
+}
+
+.btn-secondary:hover {
+  background-color: #e5e7eb;
+}
+
+.btn-danger {
+  background-color: #ef4444;
+  color: white;
+}
+
+.btn-danger:hover {
+  background-color: #dc2626;
+}
+
+/* Disabled State */
+.btn-disabled,
+.btn:disabled {
+  background-color: #d1d5db !important;
+  color: #9ca3af !important;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-google {
+  background-color: white;
+  color: #444;
+  border: 1px solid #ccc;
+  padding: 10px 20px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+}
+
+.btn-google:hover {
+  background-color: #f5f5f5;
+}

--- a/src/lib/button/Button.jsx
+++ b/src/lib/button/Button.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import "./Button.css";
+
+const Button = ({
+  children,
+  onClick,
+  variant = "primary", // 'primary' | 'secondary' | 'danger'
+  disabled = false,
+  type = "button",
+}) => {
+  return (
+    <button
+      className={`btn btn-${variant} ${disabled ? "btn-disabled" : ""}`}
+      onClick={onClick}
+      disabled={disabled}
+      type={type}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION




1. This PR does the following: creating a lib folder and creating a demo button and adding it to the home page    and login for better UI folder structure. 

## Essential Checklist


- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] The PR is made from a branch that's **not** called "main/master".

## Proof that changes are correct

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/7a2687f7-b9d5-4786-8323-175516d2fd77" />

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/6afedb3c-4d30-4a76-ac72-0fdab02f7e3f" />

